### PR TITLE
# [BE] feat: 알림 수신 설정 기능 추가 Refs #08

### DIFF
--- a/src/main/java/com/jiujitsu/api/domain/community/comment/service/CommunityCommentsService.java
+++ b/src/main/java/com/jiujitsu/api/domain/community/comment/service/CommunityCommentsService.java
@@ -144,16 +144,24 @@ public class CommunityCommentsService {
         User boardWriter = content.getCreatedBy();
 
         // 알림1 - 게시글에 댓글 달렸을 때 게시글 작성자에게
-        if (!Objects.equals(user.getId(), boardWriter.getId())) {
-            FcmPushType pushType = FcmPushType.NEW_COMMENTS;
+        FcmPushType pushType2 = FcmPushType.NEW_COMMENTS;
 
-            Map<String, String> pushData = new HashMap<>();
-            pushData.put("type", pushType.getActionType().toString());
-            pushData.put("data", content.getId().toString());
+        Map<String, String> pushData2 = new HashMap<>();
+        pushData2.put("type", pushType2.getActionType().toString());
+        pushData2.put("data", content.getId().toString());
 
-            fcmPushEventPublisher.publish(boardWriter.getId(), pushType, pushData);
-            noticeService.saveNotice(boardWriter.getId(), pushType, pushData);
-        }
+        fcmPushEventPublisher.publish(boardWriter.getId(), pushType2, pushData2);
+        noticeService.saveNotice(boardWriter.getId(), pushType2, pushData2);
+//        if (!Objects.equals(user.getId(), boardWriter.getId())) {
+//            FcmPushType pushType = FcmPushType.NEW_COMMENTS;
+//
+//            Map<String, String> pushData = new HashMap<>();
+//            pushData.put("type", pushType.getActionType().toString());
+//            pushData.put("data", content.getId().toString());
+//
+//            fcmPushEventPublisher.publish(boardWriter.getId(), pushType, pushData);
+//            noticeService.saveNotice(boardWriter.getId(), pushType, pushData);
+//        }
 
         // 알림2 - 댓글에 대댓글 달렸을 때 댓글 작성자에게
         if (parentComments.isPresent()) {

--- a/src/main/java/com/jiujitsu/api/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/jiujitsu/api/domain/notice/controller/NoticeController.java
@@ -1,6 +1,8 @@
 package com.jiujitsu.api.domain.notice.controller;
 
 import com.jiujitsu.api.domain.notice.dto.NoticeListResponse;
+import com.jiujitsu.api.domain.notice.dto.NoticeSettingRequest;
+import com.jiujitsu.api.domain.notice.dto.NoticeSettingResponse;
 import com.jiujitsu.api.domain.notice.service.NoticeService;
 import com.jiujitsu.api.global.exception.ErrorCode;
 import com.jiujitsu.api.global.exception.annotation.ApiErrorCodeExamples;
@@ -39,5 +41,11 @@ public class NoticeController {
             @Parameter(name = "id", description = "알림 ID", required = true) @PathVariable(name = "id") Long id
     ) {
         return noticeService.readNotice(id);
+    }
+
+    @Operation(summary = "알림 수신 설정", description = "알림 타입별로 수신여부 설정합니다.")
+    @PostMapping("/setting")
+    public NoticeSettingResponse settingNotice(@RequestBody NoticeSettingRequest request) {
+        return noticeService.saveNoticeSetting(request);
     }
 }

--- a/src/main/java/com/jiujitsu/api/domain/notice/dto/NoticeSettingRequest.java
+++ b/src/main/java/com/jiujitsu/api/domain/notice/dto/NoticeSettingRequest.java
@@ -1,0 +1,21 @@
+package com.jiujitsu.api.domain.notice.dto;
+
+import com.jiujitsu.api.domain.notice.entity.UserNoticeSetting;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "알림 수신동의여부 요청")
+public record NoticeSettingRequest(
+        @Schema(description = "계정보안알림") Boolean securityEnabled,
+        @Schema(description = "서비스공지알림") Boolean serviceEnabled,
+        @Schema(description = "커뮤니티활동알림") Boolean communityEnabled,
+        @Schema(description = "마케팅정보알림") Boolean marketingEnabled
+) {
+    public UserNoticeSetting toEntity() {
+        return UserNoticeSetting.builder()
+                .securityEnabled(this.securityEnabled)
+                .serviceEnabled(this.serviceEnabled)
+                .communityEnabled(this.communityEnabled)
+                .marketingEnabled(this.marketingEnabled)
+                .build();
+    }
+}

--- a/src/main/java/com/jiujitsu/api/domain/notice/dto/NoticeSettingResponse.java
+++ b/src/main/java/com/jiujitsu/api/domain/notice/dto/NoticeSettingResponse.java
@@ -1,0 +1,12 @@
+package com.jiujitsu.api.domain.notice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "알림 수신동의여부 응답")
+public record NoticeSettingResponse(
+        @Schema(description = "계정보안알림") Boolean securityEnabled,
+        @Schema(description = "서비스공지알림") Boolean serviceEnabled,
+        @Schema(description = "커뮤니티활동알림") Boolean communityEnabled,
+        @Schema(description = "마케팅정보알림") Boolean marketingEnabled
+) {
+}

--- a/src/main/java/com/jiujitsu/api/domain/notice/entity/UserNoticeSetting.java
+++ b/src/main/java/com/jiujitsu/api/domain/notice/entity/UserNoticeSetting.java
@@ -1,0 +1,65 @@
+package com.jiujitsu.api.domain.notice.entity;
+
+import com.jiujitsu.api.domain.notice.dto.NoticeSettingRequest;
+import com.jiujitsu.api.domain.user.entity.User;
+import com.jiujitsu.api.global.fcm.entity.NoticeGroupType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "user_notice_setting")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserNoticeSetting {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column
+    private Boolean securityEnabled;    // 계정보안알림
+
+    @Column
+    private Boolean serviceEnabled;     // 서비스공지알림
+
+    @Column
+    private Boolean communityEnabled;   // 커뮤니티활동알림
+
+    @Column
+    private Boolean marketingEnabled;   // 마케팅정보알림
+
+    @OneToOne
+    private User user;
+
+    public UserNoticeSetting(User user) {
+        this.securityEnabled = true;
+        this.serviceEnabled = true;
+        this.communityEnabled = true;
+        this.marketingEnabled = false;
+        this.user = user;
+    }
+
+    public void update(NoticeSettingRequest request) {
+        this.securityEnabled = request.securityEnabled();
+        this.serviceEnabled = request.serviceEnabled();
+        this.communityEnabled = request.communityEnabled();
+        this.marketingEnabled = request.marketingEnabled();
+    }
+
+    public Boolean getEnabledByPushType(NoticeGroupType noticeGroupType) {
+        boolean enabled = false;
+
+        switch (noticeGroupType) {
+            case SECURITY -> enabled = this.securityEnabled;
+            case SERVICE -> enabled = this.serviceEnabled;
+            case COMMUNITY -> enabled = this.communityEnabled;
+            case MARKETING -> enabled = this.marketingEnabled;
+        }
+
+        return enabled;
+    }
+}

--- a/src/main/java/com/jiujitsu/api/domain/notice/mapper/NoticeMapper.java
+++ b/src/main/java/com/jiujitsu/api/domain/notice/mapper/NoticeMapper.java
@@ -1,7 +1,9 @@
 package com.jiujitsu.api.domain.notice.mapper;
 
 import com.jiujitsu.api.domain.notice.dto.NoticeListResponse;
+import com.jiujitsu.api.domain.notice.dto.NoticeSettingResponse;
 import com.jiujitsu.api.domain.notice.entity.Notice;
+import com.jiujitsu.api.domain.notice.entity.UserNoticeSetting;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,6 +18,15 @@ public class NoticeMapper {
                 notice.getData(),
                 notice.getIsRead(),
                 notice.getCreatedAt()
+        );
+    }
+
+    public static NoticeSettingResponse toNoticeSettingResponse(UserNoticeSetting userNoticeSetting) {
+        return new NoticeSettingResponse(
+                userNoticeSetting.getSecurityEnabled(),
+                userNoticeSetting.getServiceEnabled(),
+                userNoticeSetting.getCommunityEnabled(),
+                userNoticeSetting.getMarketingEnabled()
         );
     }
 }

--- a/src/main/java/com/jiujitsu/api/domain/notice/repository/UserNoticeSettingRepository.java
+++ b/src/main/java/com/jiujitsu/api/domain/notice/repository/UserNoticeSettingRepository.java
@@ -1,0 +1,9 @@
+package com.jiujitsu.api.domain.notice.repository;
+
+import com.jiujitsu.api.domain.notice.entity.UserNoticeSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserNoticeSettingRepository extends JpaRepository<UserNoticeSetting, Long> {
+}

--- a/src/main/java/com/jiujitsu/api/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/jiujitsu/api/domain/notice/service/NoticeService.java
@@ -1,10 +1,14 @@
 package com.jiujitsu.api.domain.notice.service;
 
 import com.jiujitsu.api.domain.notice.dto.NoticeListResponse;
+import com.jiujitsu.api.domain.notice.dto.NoticeSettingRequest;
+import com.jiujitsu.api.domain.notice.dto.NoticeSettingResponse;
 import com.jiujitsu.api.domain.notice.entity.Notice;
+import com.jiujitsu.api.domain.notice.entity.UserNoticeSetting;
 import com.jiujitsu.api.domain.notice.factory.NoticeFactory;
 import com.jiujitsu.api.domain.notice.mapper.NoticeMapper;
 import com.jiujitsu.api.domain.notice.repository.NoticeRepository;
+import com.jiujitsu.api.domain.notice.repository.UserNoticeSettingRepository;
 import com.jiujitsu.api.domain.user.entity.User;
 import com.jiujitsu.api.domain.user.service.AuthenticationFacade;
 import com.jiujitsu.api.global.exception.ErrorCode;
@@ -27,6 +31,7 @@ public class NoticeService {
     private final NoticeFactory noticeFactory;
     private final NoticeMapper noticeMapper;
     private final AuthenticationFacade authenticationFacade;
+    private final UserNoticeSettingRepository userNoticeSettingRepository;
 
     /**
      * 알림 목록 조회
@@ -55,6 +60,7 @@ public class NoticeService {
         notices.forEach(Notice::setRead);
         return true;
     }
+
     /**
      * 알림 개별 읽음 처리
      */
@@ -82,5 +88,19 @@ public class NoticeService {
     public void saveNotice(Long userId, FcmPushType pushType, Map<String, String> pushData) {
         Notice notice = noticeFactory.createNotice(userId, pushType, pushData);
         noticeRepository.save(notice);
+    }
+
+    /**
+     * 알림 수신동의여부 저장
+     */
+    public NoticeSettingResponse saveNoticeSetting(NoticeSettingRequest request) {
+        User user = authenticationFacade.getCurrentUser();
+
+        UserNoticeSetting userNoticeSetting = user.getUserNoticeSetting();
+        userNoticeSetting.update(request);
+
+        userNoticeSettingRepository.save(userNoticeSetting);
+
+        return NoticeMapper.toNoticeSettingResponse(userNoticeSetting);
     }
 }

--- a/src/main/java/com/jiujitsu/api/domain/user/entity/User.java
+++ b/src/main/java/com/jiujitsu/api/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.jiujitsu.api.domain.user.entity;
 
+import com.jiujitsu.api.domain.notice.entity.UserNoticeSetting;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -67,6 +68,9 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<UserAppInfo> appInfos = new ArrayList<>();
+
+    @OneToOne
+    private UserNoticeSetting userNoticeSetting;
 
     public void updateProfile(String nickname, String profileImageUrl) {
         if (nickname != null && !nickname.trim().isEmpty()) {

--- a/src/main/java/com/jiujitsu/api/domain/user/service/UserService.java
+++ b/src/main/java/com/jiujitsu/api/domain/user/service/UserService.java
@@ -4,6 +4,8 @@ import com.jiujitsu.api.domain.community.profile.entity.CommunityProfile;
 import com.jiujitsu.api.domain.community.profile.entity.OwnerProfile;
 import com.jiujitsu.api.domain.community.profile.repository.CommunityProfileRepository;
 import com.jiujitsu.api.domain.community.profile.repository.OwnerProfileRepository;
+import com.jiujitsu.api.domain.notice.entity.UserNoticeSetting;
+import com.jiujitsu.api.domain.notice.repository.UserNoticeSettingRepository;
 import com.jiujitsu.api.domain.user.dto.*;
 import com.jiujitsu.api.domain.user.entity.*;
 import com.jiujitsu.api.domain.user.factory.UserFactory;
@@ -37,6 +39,7 @@ public class UserService {
     private final OwnerProfileRepository ownerProfileRepository;
     private final CommunityProfileRepository communityProfileRepository;
     private final UserAppInfoRepository userAppInfoRepository;
+    private final UserNoticeSettingRepository userNoticeSettingRepository;
     private final TokenBlacklistService tokenBlacklistService;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationFacade authenticationFacade;
@@ -79,6 +82,8 @@ public class UserService {
                 )
         );
 
+        UserNoticeSetting userNoticeSetting = userNoticeSettingRepository.save(new UserNoticeSetting(user));
+        user.setUserNoticeSetting(userNoticeSetting);
         return userRepository.save(user);
     }
 

--- a/src/main/java/com/jiujitsu/api/global/fcm/entity/FcmPushType.java
+++ b/src/main/java/com/jiujitsu/api/global/fcm/entity/FcmPushType.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import static com.jiujitsu.api.global.fcm.entity.NoticeGroupType.COMMUNITY;
 import static com.jiujitsu.api.global.fcm.entity.PushActionType.BOARD_DETAIL;
 
 @NoArgsConstructor
@@ -11,12 +12,13 @@ import static com.jiujitsu.api.global.fcm.entity.PushActionType.BOARD_DETAIL;
 @Getter
 public enum FcmPushType {
 
-    NEW_COMMENTS("내 게시글에 새로운 댓글이 달렸어요.", null, BOARD_DETAIL),
-    NEW_CHILD_COMMENTS("내 댓글에 답글이 달렸어요.", null, BOARD_DETAIL),
-    CONTENTS_LIKE("내 게시글에 좋아요가 달렸어요.", null, BOARD_DETAIL),
-    COMMENTS_LIKE("내 댓글에 좋아요가 달렸어요.", null, BOARD_DETAIL);
+    NEW_COMMENTS("내 게시글에 새로운 댓글이 달렸어요.", null, BOARD_DETAIL, COMMUNITY),
+    NEW_CHILD_COMMENTS("내 댓글에 답글이 달렸어요.", null, BOARD_DETAIL, COMMUNITY),
+    CONTENTS_LIKE("내 게시글에 좋아요가 달렸어요.", null, BOARD_DETAIL, COMMUNITY),
+    COMMENTS_LIKE("내 댓글에 좋아요가 달렸어요.", null, BOARD_DETAIL, COMMUNITY);
 
     private String title;
     private String body;
     private PushActionType actionType;
+    private NoticeGroupType noticeGroupType;
 }

--- a/src/main/java/com/jiujitsu/api/global/fcm/entity/NoticeGroupType.java
+++ b/src/main/java/com/jiujitsu/api/global/fcm/entity/NoticeGroupType.java
@@ -1,0 +1,13 @@
+package com.jiujitsu.api.global.fcm.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public enum NoticeGroupType {
+    SECURITY,
+    SERVICE,
+    COMMUNITY,
+    MARKETING
+}

--- a/src/main/java/com/jiujitsu/api/global/fcm/event/FcmPushEventPublisher.java
+++ b/src/main/java/com/jiujitsu/api/global/fcm/event/FcmPushEventPublisher.java
@@ -1,5 +1,7 @@
 package com.jiujitsu.api.global.fcm.event;
 
+import com.jiujitsu.api.domain.notice.entity.UserNoticeSetting;
+import com.jiujitsu.api.domain.user.service.AuthenticationFacade;
 import com.jiujitsu.api.global.fcm.entity.FcmPushType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -12,11 +14,19 @@ import java.util.Map;
 public class FcmPushEventPublisher {
 
     private final ApplicationEventPublisher eventPublisher;
+    private final AuthenticationFacade authenticationFacade;
 
     public void publish(Long recipientUserId, FcmPushType pushType, Map<String, String> data) {
         if (recipientUserId == null || pushType == null) {
             return;
         }
+
+        // 수신 거부 여부 체크
+        UserNoticeSetting userNoticeSetting = authenticationFacade.getCurrentUser().getUserNoticeSetting();
+        if (!userNoticeSetting.getEnabledByPushType(pushType.getNoticeGroupType())) {
+            return;
+        }
+
         eventPublisher.publishEvent(new FcmPushRequestedEvent(recipientUserId, pushType, data));
     }
 }


### PR DESCRIPTION
## 📝 변경 사항
- UserNoticeSetting 엔티티 추가 (계정보안/서비스공지/커뮤니티/마케팅 수신 여부)
- NoticeGroupType enum 추가 및 FcmPushType에 그룹 타입 연결
- POST /notice/setting API 추가로 알림 타입별 수신 여부 설정
- 유저 가입 시 기본 알림 설정 자동 생성
- FcmPushEventPublisher에서 수신 거부 시 FCM 발송 차단
- 댓글 알림: 본인 게시글 여부 관계없이 알림 발송하도록 수정


## ✅ 체크
- [ ㅇ ] 동작 확인
- [ ] 테스트 / 문서 업데이트 (필요 시)

<!-- 관련 이슈 있으면 본문 어디든 "Closes #123" 추가 (없으면 생략) -->
