### PR TITLE
# [BE] feat: 유저 차단 기능 추가 Refs #08

### DIFF
--- a/src/main/java/com/jiujitsu/api/domain/community/board/repository/BoardRepository.java
+++ b/src/main/java/com/jiujitsu/api/domain/community/board/repository/BoardRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -26,6 +27,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findByTitleBodyKeyword(@Param("keyword") String keyword, Pageable pageable);
 
     Page<Board> findAllByCreatedBy(User createdBy, Pageable pageable);
+
     @Query("""
     select b
     from ContentSave cs
@@ -34,4 +36,32 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     where cs.createdBy.id = :userId
     """)
     Page<Board> findSavedBoards(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+    select b from Board b
+    where b.category.id = :categoryId
+    and b.createdBy.id not in :blockedUserIds
+    """)
+    Page<Board> findAllByCategoryExcludingBlockedUsers(
+            @Param("categoryId") Long categoryId,
+            @Param("blockedUserIds") List<Long> blockedUserIds,
+            Pageable pageable);
+
+    @Query("""
+    select b from Board b
+    where (b.title like %:keyword% or b.body like %:keyword%)
+    and b.createdBy.id not in :blockedUserIds
+    """)
+    Page<Board> findByTitleBodyKeywordExcludingBlockedUsers(
+            @Param("keyword") String keyword,
+            @Param("blockedUserIds") List<Long> blockedUserIds,
+            Pageable pageable);
+
+    @Query("""
+    select b from Board b
+    where b.createdBy.id not in :blockedUserIds
+    """)
+    Page<Board> findAllExcludingBlockedUsers(
+            @Param("blockedUserIds") List<Long> blockedUserIds,
+            Pageable pageable);
 }

--- a/src/main/java/com/jiujitsu/api/domain/community/board/service/BoardService.java
+++ b/src/main/java/com/jiujitsu/api/domain/community/board/service/BoardService.java
@@ -12,6 +12,7 @@ import com.jiujitsu.api.domain.community.content.entity.Content;
 import com.jiujitsu.api.domain.community.content.service.ContentService;
 import com.jiujitsu.api.domain.user.entity.User;
 import com.jiujitsu.api.domain.user.service.AuthenticationFacade;
+import com.jiujitsu.api.domain.user.service.UserBlockService;
 import com.jiujitsu.api.global.exception.ErrorCode;
 import com.jiujitsu.api.global.exception.ErrorException;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,7 @@ public class BoardService {
     private final BoardCategoryService boardCategoryService;
     private final CommunityCommentsService communityCommentsService;
     private final ContentService contentService;
+    private final UserBlockService userBlockService;
 
     /**
      * 게시물 목록 조회
@@ -44,18 +46,25 @@ public class BoardService {
     @Transactional(readOnly = true)
     public Page<BoardListResponse> getList(BoardListRequest boardListRequest, Pageable pageable) {
         BoardListType boardListType = boardListRequest.boardListType();
+        List<Long> blockedUserIds = userBlockService.getBlockedUserIds();
 
         // 게시판 조회
         Page<Board> page = switch (boardListType) {
             case CATEGORY -> {
                 Long categoryId = boardListRequest.categoryId();
-                yield boardRepository.findAllByCategory_Id(categoryId, pageable);
+                yield blockedUserIds.isEmpty()
+                        ? boardRepository.findAllByCategory_Id(categoryId, pageable)
+                        : boardRepository.findAllByCategoryExcludingBlockedUsers(categoryId, blockedUserIds, pageable);
             }
             case SEARCH -> {
                 String keyword = StringUtils.trimToEmpty(boardListRequest.searchKeyword()).toUpperCase(Locale.ROOT);
-                yield boardRepository.findByTitleBodyKeyword(keyword, pageable);
+                yield blockedUserIds.isEmpty()
+                        ? boardRepository.findByTitleBodyKeyword(keyword, pageable)
+                        : boardRepository.findByTitleBodyKeywordExcludingBlockedUsers(keyword, blockedUserIds, pageable);
             }
-            default -> boardRepository.findAll(pageable);
+            default -> blockedUserIds.isEmpty()
+                    ? boardRepository.findAll(pageable)
+                    : boardRepository.findAllExcludingBlockedUsers(blockedUserIds, pageable);
         };
 
         // 컨텐츠(공통) 조회

--- a/src/main/java/com/jiujitsu/api/domain/community/comment/repository/CommunityCommentsRepository.java
+++ b/src/main/java/com/jiujitsu/api/domain/community/comment/repository/CommunityCommentsRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -43,4 +44,14 @@ public interface CommunityCommentsRepository extends JpaRepository<CommunityComm
       and c.content.id in :contentIds
     """)
     Set<Long> findUserCommentedContentIds(@Param("userId")Long userId, @Param("contentIds")List<Long> contentIds);
+
+    @Query("""
+    select c from CommunityComments c
+    where c.content.id = :contentId
+    and c.createdBy.id not in :blockedUserIds
+    order by c.createdAt desc
+    """)
+    List<CommunityComments> findByContentIdExcludingBlockedUsersOrderByCreatedAtDesc(
+            @Param("contentId") Long contentId,
+            @Param("blockedUserIds") Collection<Long> blockedUserIds);
 }

--- a/src/main/java/com/jiujitsu/api/domain/community/comment/service/CommunityCommentsService.java
+++ b/src/main/java/com/jiujitsu/api/domain/community/comment/service/CommunityCommentsService.java
@@ -19,6 +19,7 @@ import com.jiujitsu.api.domain.community.content.repository.ContentRepository;
 import com.jiujitsu.api.domain.notice.service.NoticeService;
 import com.jiujitsu.api.domain.user.entity.User;
 import com.jiujitsu.api.domain.user.service.AuthenticationFacade;
+import com.jiujitsu.api.domain.user.service.UserBlockService;
 import com.jiujitsu.api.global.exception.ErrorCode;
 import com.jiujitsu.api.global.exception.ErrorException;
 import com.jiujitsu.api.global.fcm.entity.FcmPushType;
@@ -42,6 +43,7 @@ public class CommunityCommentsService {
     private final CommunityCommentsRepository communityCommentsRepository;
     private final ContentRepository contentRepository;
     private final AuthenticationFacade authenticationFacade;
+    private final UserBlockService userBlockService;
     private final FcmPushEventPublisher fcmPushEventPublisher;
     private final CommentFactory commentFactory;
     private final CommentMapper commentMapper;
@@ -63,7 +65,10 @@ public class CommunityCommentsService {
                 .orElseThrow(() -> new ErrorException(ErrorCode.CONTENT_NOT_FOUND));
 
         // 댓글 전체 리스트 조회(댓글+대댓글) > n+1 조회 이슈로 전체 조회 후 여기서 세팅...
-        List<CommunityComments> comments = communityCommentsRepository.findByContentIdOrderByCreatedAtDesc(contentId);
+        List<Long> blockedUserIds = userBlockService.getBlockedUserIds();
+        List<CommunityComments> comments = blockedUserIds.isEmpty()
+                ? communityCommentsRepository.findByContentIdOrderByCreatedAtDesc(contentId)
+                : communityCommentsRepository.findByContentIdExcludingBlockedUsersOrderByCreatedAtDesc(contentId, blockedUserIds);
 
 
         // 좋아요 조회(n+1 방지 > 전체 조회 후 mapping)

--- a/src/main/java/com/jiujitsu/api/domain/notice/entity/UserNoticeSetting.java
+++ b/src/main/java/com/jiujitsu/api/domain/notice/entity/UserNoticeSetting.java
@@ -6,8 +6,6 @@ import com.jiujitsu.api.global.fcm.entity.NoticeGroupType;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.Objects;
-
 @Entity
 @Table(name = "user_notice_setting")
 @Getter
@@ -17,7 +15,7 @@ import java.util.Objects;
 @AllArgsConstructor
 public class UserNoticeSetting {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column

--- a/src/main/java/com/jiujitsu/api/domain/user/controller/UserBlockController.java
+++ b/src/main/java/com/jiujitsu/api/domain/user/controller/UserBlockController.java
@@ -1,0 +1,31 @@
+package com.jiujitsu.api.domain.user.controller;
+
+import com.jiujitsu.api.domain.user.service.UserBlockService;
+import com.jiujitsu.api.global.exception.ErrorCode;
+import com.jiujitsu.api.global.exception.annotation.ApiErrorCodeExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "user-block-controller", description = "사용자 차단 API")
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserBlockController {
+
+    private final UserBlockService userBlockService;
+
+    @Operation(
+            summary = "유저 차단/차단 해제",
+            description = "특정 유저를 차단하거나 차단 해제합니다. 이미 차단된 유저를 다시 요청하면 차단이 해제됩니다. (true = 차단, false = 차단 해제)"
+    )
+    @ApiErrorCodeExamples({ErrorCode.USER_NOT_FOUND, ErrorCode.SELF_BLOCK_NOT_ALLOWED, ErrorCode.AUTHENTICATION_FAILED})
+    @PostMapping("/block/{userId}")
+    public Boolean toggleBlock(
+            @Parameter(name = "userId", description = "차단할 유저 ID", required = true) @PathVariable Long userId
+    ) {
+        return userBlockService.toggleBlock(userId);
+    }
+}

--- a/src/main/java/com/jiujitsu/api/domain/user/entity/UserBlock.java
+++ b/src/main/java/com/jiujitsu/api/domain/user/entity/UserBlock.java
@@ -1,0 +1,37 @@
+package com.jiujitsu.api.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "user_block",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"blocker_id", "blocked_id"})
+)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class UserBlock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocker_id", nullable = false)
+    private User blocker;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked_id", nullable = false)
+    private User blocked;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/jiujitsu/api/domain/user/repository/UserBlockRepository.java
+++ b/src/main/java/com/jiujitsu/api/domain/user/repository/UserBlockRepository.java
@@ -1,0 +1,20 @@
+package com.jiujitsu.api.domain.user.repository;
+
+import com.jiujitsu.api.domain.user.entity.User;
+import com.jiujitsu.api.domain.user.entity.UserBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+
+    Optional<UserBlock> findByBlockerAndBlocked(User blocker, User blocked);
+
+    @Query("SELECT ub.blocked.id FROM UserBlock ub WHERE ub.blocker.id = :blockerId")
+    List<Long> findBlockedIdsByBlockerId(@Param("blockerId") Long blockerId);
+}

--- a/src/main/java/com/jiujitsu/api/domain/user/service/UserBlockService.java
+++ b/src/main/java/com/jiujitsu/api/domain/user/service/UserBlockService.java
@@ -1,0 +1,63 @@
+package com.jiujitsu.api.domain.user.service;
+
+import com.jiujitsu.api.domain.user.entity.User;
+import com.jiujitsu.api.domain.user.entity.UserBlock;
+import com.jiujitsu.api.domain.user.repository.UserBlockRepository;
+import com.jiujitsu.api.domain.user.repository.UserRepository;
+import com.jiujitsu.api.global.exception.ErrorCode;
+import com.jiujitsu.api.global.exception.ErrorException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserBlockService {
+
+    private final AuthenticationFacade authenticationFacade;
+    private final UserRepository userRepository;
+    private final UserBlockRepository userBlockRepository;
+
+    /**
+     * 유저 차단/차단 해제 (toggle)
+     * @return true = 차단, false = 차단 해제
+     */
+    public boolean toggleBlock(Long blockedUserId) {
+        User blocker = authenticationFacade.getCurrentUser();
+
+        if (blocker.getId().equals(blockedUserId)) {
+            throw new ErrorException(ErrorCode.SELF_BLOCK_NOT_ALLOWED);
+        }
+
+        User blocked = userRepository.findById(blockedUserId)
+                .orElseThrow(() -> new ErrorException(ErrorCode.USER_NOT_FOUND));
+
+        Optional<UserBlock> existing = userBlockRepository.findByBlockerAndBlocked(blocker, blocked);
+
+        if (existing.isPresent()) {
+            userBlockRepository.delete(existing.get());
+            return false;
+        } else {
+            userBlockRepository.save(UserBlock.builder()
+                    .blocker(blocker)
+                    .blocked(blocked)
+                    .build());
+            return true;
+        }
+    }
+
+    /**
+     * 현재 로그인 유저가 차단한 유저 ID 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<Long> getBlockedUserIds() {
+        return authenticationFacade.getCurrentUserOptional()
+                .map(user -> userBlockRepository.findBlockedIdsByBlockerId(user.getId()))
+                .orElse(Collections.emptyList());
+    }
+}

--- a/src/main/java/com/jiujitsu/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/jiujitsu/api/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     PERMISSION_DENIED(403, "U0003", "권한이 없습니다."),
     USER_ALREADY_DEACTIVATED(400, "U0004", "이미 탈퇴 처리된 계정입니다."),
     USER_ACCOUNT_EXPIRED(400, "U0005", "탈퇴 후 30일이 지나 계정이 영구 삭제되었습니다."),
+    SELF_BLOCK_NOT_ALLOWED(400, "U0006", "자기 자신을 차단할 수 없습니다."),
 
     /**
      * 인증 에러


### PR DESCRIPTION
## 📝 변경 사항
- UserBlock 엔티티 및 차단/해제/조회 API 구현
- 게시글·댓글 목록 조회 시 차단 유저 콘텐츠 필터링 적용
- 자기 자신 차단 방지 에러코드(U0006) 추가
- UserNoticeSetting GenerationType AUTO → IDENTITY 수정

## ✅ 체크
- [ㅇ ] 동작 확인
- [ ] 테스트 / 문서 업데이트 (필요 시)

