### PR TITLE
# [BE] feat: 게시물 숨김 기능 구현

### DIFF
--- a/src/main/java/com/jiujitsu/api/domain/community/board/controller/BoardController.java
+++ b/src/main/java/com/jiujitsu/api/domain/community/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package com.jiujitsu.api.domain.community.board.controller;
 
 import com.jiujitsu.api.domain.community.board.dto.*;
 import com.jiujitsu.api.domain.community.board.service.BoardCategoryService;
+import com.jiujitsu.api.domain.community.board.service.BoardHideService;
 import com.jiujitsu.api.domain.community.board.service.BoardService;
 import com.jiujitsu.api.domain.community.content.dto.ContentLikeResponse;
 import com.jiujitsu.api.domain.community.content.dto.ContentSaveResponse;
@@ -32,6 +33,7 @@ public class BoardController {
 
     private final BoardService boardService;
     private final BoardCategoryService boardCategoryService;
+    private final BoardHideService boardHideService;
     private final ContentService contentService;
 
     /**
@@ -112,6 +114,16 @@ public class BoardController {
             @Parameter(name = "id", description = "게시글 ID", required = true) @PathVariable(name = "id") Long id
     ) {
         return contentService.save(id);
+    }
+
+    @Operation(summary = "게시물 숨김/숨김해제", description = "게시물을 숨기거나 숨김 해제합니다. (true = 숨김, false = 숨김해제)")
+    @LoginErrorExamples
+    @ApiErrorCodeExamples({ErrorCode.BOARD_NOT_FOUND, ErrorCode.SELF_HIDE_NOT_ALLOWED})
+    @PutMapping("/hide/{id}")
+    public Boolean hide(
+            @Parameter(name = "id", description = "게시글 ID", required = true) @PathVariable(name = "id") Long id
+    ) {
+        return boardHideService.toggleHide(id);
     }
 
     @Operation(summary = "내가 작성한 글 조회", description = "내가 작성한 글 목록을 조회합니다.")

--- a/src/main/java/com/jiujitsu/api/domain/community/board/entity/BoardHide.java
+++ b/src/main/java/com/jiujitsu/api/domain/community/board/entity/BoardHide.java
@@ -1,0 +1,27 @@
+package com.jiujitsu.api.domain.community.board.entity;
+
+import com.jiujitsu.api.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "board_hide",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"created_by", "content_id"})
+)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardHide extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content_id", nullable = false)
+    private Long contentId;
+}

--- a/src/main/java/com/jiujitsu/api/domain/community/board/repository/BoardHideRepository.java
+++ b/src/main/java/com/jiujitsu/api/domain/community/board/repository/BoardHideRepository.java
@@ -1,0 +1,19 @@
+package com.jiujitsu.api.domain.community.board.repository;
+
+import com.jiujitsu.api.domain.community.board.entity.BoardHide;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BoardHideRepository extends JpaRepository<BoardHide, Long> {
+
+    Optional<BoardHide> findByCreatedByIdAndContentId(Long userId, Long contentId);
+
+    @Query("SELECT bh.contentId FROM BoardHide bh WHERE bh.createdBy.id = :userId")
+    List<Long> findContentIdsByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/jiujitsu/api/domain/community/board/service/BoardHideService.java
+++ b/src/main/java/com/jiujitsu/api/domain/community/board/service/BoardHideService.java
@@ -1,0 +1,64 @@
+package com.jiujitsu.api.domain.community.board.service;
+
+import com.jiujitsu.api.domain.community.board.entity.Board;
+import com.jiujitsu.api.domain.community.board.entity.BoardHide;
+import com.jiujitsu.api.domain.community.board.repository.BoardHideRepository;
+import com.jiujitsu.api.domain.community.board.repository.BoardRepository;
+import com.jiujitsu.api.domain.user.entity.User;
+import com.jiujitsu.api.domain.user.service.AuthenticationFacade;
+import com.jiujitsu.api.global.exception.ErrorCode;
+import com.jiujitsu.api.global.exception.ErrorException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardHideService {
+
+    private final AuthenticationFacade authenticationFacade;
+    private final BoardHideRepository boardHideRepository;
+    private final BoardRepository boardRepository;
+
+    /**
+     * 게시물 숨김/숨김해제 (toggle)
+     * @return true = 숨김, false = 숨김해제
+     */
+    public boolean toggleHide(Long contentId) {
+        User user = authenticationFacade.getCurrentUser();
+
+        Board board = boardRepository.findByContent_Id(contentId)
+                .orElseThrow(() -> new ErrorException(ErrorCode.BOARD_NOT_FOUND));
+
+        if (user.equals(board.getCreatedBy())) {
+            throw new ErrorException(ErrorCode.SELF_HIDE_NOT_ALLOWED);
+        }
+
+        Optional<BoardHide> existing = boardHideRepository.findByCreatedByIdAndContentId(user.getId(), contentId);
+
+        if (existing.isPresent()) {
+            boardHideRepository.delete(existing.get());
+            return false;
+        } else {
+            boardHideRepository.save(BoardHide.builder()
+                    .contentId(contentId)
+                    .build());
+            return true;
+        }
+    }
+
+    /**
+     * 현재 로그인 유저가 숨긴 게시물 content ID 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<Long> getHiddenContentIds() {
+        return authenticationFacade.getCurrentUserOptional()
+                .map(user -> boardHideRepository.findContentIdsByUserId(user.getId()))
+                .orElse(Collections.emptyList());
+    }
+}

--- a/src/main/java/com/jiujitsu/api/domain/community/board/service/BoardService.java
+++ b/src/main/java/com/jiujitsu/api/domain/community/board/service/BoardService.java
@@ -7,6 +7,7 @@ import com.jiujitsu.api.domain.community.board.entity.BoardListType;
 import com.jiujitsu.api.domain.community.board.factory.BoardFactory;
 import com.jiujitsu.api.domain.community.board.mapper.BoardMapper;
 import com.jiujitsu.api.domain.community.board.repository.BoardRepository;
+import com.jiujitsu.api.domain.community.board.service.BoardHideService;
 import com.jiujitsu.api.domain.community.comment.service.CommunityCommentsService;
 import com.jiujitsu.api.domain.community.content.entity.Content;
 import com.jiujitsu.api.domain.community.content.service.ContentService;
@@ -27,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -44,6 +46,7 @@ public class BoardService {
     private final UserBlockService userBlockService;
     private final NoticeService noticeService;
     private final ReportService reportService;
+    private final BoardHideService boardHideService;
 
     /**
      * 게시물 목록 조회
@@ -53,10 +56,13 @@ public class BoardService {
         BoardListType boardListType = boardListRequest.boardListType();
         List<Long> blockedUserIds = userBlockService.getBlockedUserIds();
         List<Long> reportedContentIds = reportService.getReportedTargetIds(ReportType.BOARD);
+        List<Long> hiddenContentIds = boardHideService.getHiddenContentIds();
 
         // 빈 리스트일 때 IN 절 오류 방지용 sentinel
         List<Long> excludedAuthorIds = blockedUserIds.isEmpty() ? List.of(-1L) : blockedUserIds;
-        List<Long> excludedContentIds = reportedContentIds.isEmpty() ? List.of(-1L) : reportedContentIds;
+        List<Long> mergedExcludedContentIds = Stream.concat(reportedContentIds.stream(), hiddenContentIds.stream())
+                .distinct().toList();
+        List<Long> excludedContentIds = mergedExcludedContentIds.isEmpty() ? List.of(-1L) : mergedExcludedContentIds;
 
         Page<Board> page = switch (boardListType) {
             case CATEGORY -> boardRepository.findAllByCategoryFiltered(

--- a/src/main/java/com/jiujitsu/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/jiujitsu/api/global/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     SELF_REPORT_NOT_ALLOWED(400, "U0007", "자신의 게시물/댓글은 신고할 수 없습니다."),
     ALREADY_REPORTED(400, "U0008", "이미 신고한 게시물/댓글입니다."),
     REPORT_NOT_FOUND(404, "U0009", "존재하지 않는 신고입니다."),
+    SELF_HIDE_NOT_ALLOWED(400, "U0010", "자신의 게시물은 숨길 수 없습니다."),
 
     /**
      * 인증 에러


### PR DESCRIPTION
## 📝 변경 사항
- BoardHide 엔티티/레포지토리/서비스 추가
- PUT /board/hide/{id} 엔드포인트 추가 (toggle, 본인 게시물 숨김 불가)
- 게시물 목록 조회 시 숨긴 게시물 미노출 처리
- ErrorCode SELF_HIDE_NOT_ALLOWED(U0010) 추가

## ✅ 체크
- [ ] 동작 확인
- [ ] 테스트 / 문서 업데이트 (필요 시)

<!-- 관련 이슈 있으면 본문 어디든 "Closes #123" 추가 (없으면 생략) -->
